### PR TITLE
Add query option to filter feature flags by name or key

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ custom API endpoint.
 
 - `maintainer-teams`: Comma-separated list of teams responsible for maintaining
   feature flags
+- `query`: Search term to filter feature flags by name or key
+  (case-insensitive). Maps to the LaunchDarkly API `query` filter.
 - `report-type`: Report type - `slack`, `api`, or `default` (default: `default`)
 - `webhook-url`: Webhook URL for sending reports (required for `slack` and `api`
   report types)

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,11 @@ inputs:
         description:
             'Maintainer teams with assigned feature flags in Launch Darkly'
         required: false
+    query:
+        description:
+            'Search term to filter feature flags by name or key
+            (case-insensitive). Maps to the LaunchDarkly API query filter.'
+        required: false
     report-type:
         description: 'Report type: slack, api, or default'
         required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -55548,6 +55548,7 @@ async function run() {
         const maintainerTeams = core
             .getInput('maintainer-teams')
             ?.split(',');
+        const query = core.getInput('query');
         core.info(`Starting request...`);
         const requestParams = {
             accessToken,
@@ -55557,10 +55558,12 @@ async function run() {
         const featureFlags = maintainerTeams.length > 0
             ? await (0, service_1.getFeatureFlagsByMaintainerTeams)({
                 maintainerTeams,
+                query,
                 ...requestParams
             })
             : await (0, service_1.getFeatureFlags)({
-                ...requestParams
+                ...requestParams,
+                filters: (0, service_1.buildFilters)([query ? `query:${query}` : ''])
             });
         if (featureFlags.length === 0) {
             core.info(`Feature Flags list is empty`);
@@ -56079,10 +56082,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getFeatureFlagsByMaintainerTeams = exports.getFeatureFlags = void 0;
+exports.getFeatureFlagsByMaintainerTeams = exports.getFeatureFlags = exports.buildFilters = void 0;
 const axios_1 = __importDefault(__nccwpck_require__(87269));
 const BASE_URL = 'https://app.launchdarkly.com';
 const API_URL = `${BASE_URL}/api/v2/flags`;
+const buildFilters = (parts) => parts.filter(Boolean).join(',');
+exports.buildFilters = buildFilters;
 const makeRequest = async (url, accessToken, params) => {
     const { data } = await axios_1.default.get(url, {
         headers: {
@@ -56120,12 +56125,16 @@ const getFeatureFlags = async ({ accessToken, projectKey, environment, filters =
     return await makePaginatedRequest(`${API_URL}/${projectKey}`, accessToken, params);
 };
 exports.getFeatureFlags = getFeatureFlags;
-const getFeatureFlagsByMaintainerTeams = async ({ accessToken, projectKey, environment, maintainerTeams }) => {
+const getFeatureFlagsByMaintainerTeams = async ({ accessToken, projectKey, environment, maintainerTeams, query }) => {
+    const queryFilter = query ? `query:${query}` : '';
     const response = await Promise.all(maintainerTeams.map(async (team) => await (0, exports.getFeatureFlags)({
         accessToken,
         projectKey,
         environment,
-        filters: `maintainerTeamKey:${team}`
+        filters: (0, exports.buildFilters)([
+            `maintainerTeamKey:${team}`,
+            queryFilter
+        ])
     })));
     return response.flat();
 };

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -1,5 +1,9 @@
 import * as core from '@actions/core'
-import { getFeatureFlags, getFeatureFlagsByMaintainerTeams } from './service'
+import {
+    buildFilters,
+    getFeatureFlags,
+    getFeatureFlagsByMaintainerTeams
+} from './service'
 import { runRulesEngine } from './rules'
 import { getReportByType } from './reports'
 import { toFeatureFlagDto } from './dto'
@@ -12,6 +16,7 @@ export async function run(): Promise<void> {
         const maintainerTeams: string[] = core
             .getInput('maintainer-teams')
             ?.split(',')
+        const query: string = core.getInput('query')
 
         core.info(`Starting request...`)
 
@@ -25,10 +30,12 @@ export async function run(): Promise<void> {
             maintainerTeams.length > 0
                 ? await getFeatureFlagsByMaintainerTeams({
                       maintainerTeams,
+                      query,
                       ...requestParams
                   })
                 : await getFeatureFlags({
-                      ...requestParams
+                      ...requestParams,
+                      filters: buildFilters([query ? `query:${query}` : ''])
                   })
 
         if (featureFlags.length === 0) {

--- a/src/service.ts
+++ b/src/service.ts
@@ -4,6 +4,9 @@ import { FeatureFlag, Response } from './types'
 const BASE_URL = 'https://app.launchdarkly.com'
 const API_URL = `${BASE_URL}/api/v2/flags`
 
+export const buildFilters = (parts: string[]): string =>
+    parts.filter(Boolean).join(',')
+
 const makeRequest = async (
     url: string,
     accessToken: string,
@@ -78,13 +81,17 @@ export const getFeatureFlagsByMaintainerTeams = async ({
     accessToken,
     projectKey,
     environment,
-    maintainerTeams
+    maintainerTeams,
+    query
 }: {
     accessToken: string
     projectKey: string
     environment: string
     maintainerTeams: string[]
+    query?: string
 }): Promise<FeatureFlag[]> => {
+    const queryFilter = query ? `query:${query}` : ''
+
     const response = await Promise.all(
         maintainerTeams.map(
             async team =>
@@ -92,7 +99,10 @@ export const getFeatureFlagsByMaintainerTeams = async ({
                     accessToken,
                     projectKey,
                     environment,
-                    filters: `maintainerTeamKey:${team}`
+                    filters: buildFilters([
+                        `maintainerTeamKey:${team}`,
+                        queryFilter
+                    ])
                 })
         )
     )


### PR DESCRIPTION
Adds a new optional `query` input that maps to the LaunchDarkly API `query` filter, allowing server-side filtering of flags by name or key (case-insensitive) before the rules engine runs.